### PR TITLE
🗺️ Interactive district map with geographic analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+dist/

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,8 @@
     "share": "Share",
     "loading": "Loading...",
     "others": "Others",
-    "seats": "seats"
+    "seats": "seats",
+    "viewFull": "View full"
   },
   "homepage": {
     "tagline": "Portuguese Election Forecast",
@@ -28,7 +29,9 @@
     "coalitionScenarios": "Coalition scenarios",
     "currentStandings": "Current standings",
     "aboutForecast": "About this forecast",
-    "aboutDescription": "This election model combines polling data, historical voting patterns, and demographic information to project likely outcomes for Portugal's parliamentary elections. The forecast is updated regularly as new data becomes available."
+    "aboutDescription": "This election model combines polling data, historical voting patterns, and demographic information to project likely outcomes for Portugal's parliamentary elections. The forecast is updated regularly as new data becomes available.",
+    "districtForecast": "District forecasts",
+    "districtDescription": "Geographic distribution of forecasts by district."
   },
   "forecast": {
     "title": "Full Election Forecast",

--- a/messages/en.json
+++ b/messages/en.json
@@ -33,6 +33,10 @@
     "districtForecast": "District forecasts",
     "districtDescription": "Geographic distribution of forecasts by district."
   },
+  "map": {
+    "voteShareByParty": "Vote Share by Party",
+    "selectDistrict": "Select a district to view detailed vote projections"
+  },
   "forecast": {
     "title": "Full Election Forecast",
     "subtitle": "Portugal Parliamentary Elections",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -33,6 +33,10 @@
     "districtForecast": "Previsões por Distrito",
     "districtDescription": "Distribuição geográfica das previsões por distrito."
   },
+  "map": {
+    "voteShareByParty": "Previsão de Votos por Partido",
+    "selectDistrict": "Selecione um distrito para ver as projeções detalhadas de votos"
+  },
   "forecast": {
     "title": "Previsão Eleitoral Completa",
     "subtitle": "Eleições Parlamentares Portuguesas",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -15,7 +15,8 @@
     "share": "Partilhar",
     "loading": "A carregar...",
     "others": "Outros",
-    "seats": "mandatos"
+    "seats": "mandatos",
+    "viewFull": "Ver completo"
   },
   "homepage": {
     "tagline": "Previsões Eleitorais Portuguesas",
@@ -28,7 +29,9 @@
     "coalitionScenarios": "Cenários de coligação",
     "currentStandings": "Situação atual",
     "aboutForecast": "Sobre esta previsão",
-    "aboutDescription": "Este modelo eleitoral combina dados de sondagens, padrões históricos de voto e informações demográficas para projetar resultados prováveis para as eleições parlamentares portuguesas. A previsão é atualizada regularmente à medida que novos dados ficam disponíveis."
+    "aboutDescription": "Este modelo eleitoral combina dados de sondagens, padrões históricos de voto e informações demográficas para projetar resultados prováveis para as eleições parlamentares portuguesas. A previsão é atualizada regularmente à medida que novos dados ficam disponíveis.",
+    "districtForecast": "Previsões por Distrito",
+    "districtDescription": "Distribuição geográfica das previsões por distrito."
   },
   "forecast": {
     "title": "Previsão Eleitoral Completa",

--- a/next.config.js
+++ b/next.config.js
@@ -9,9 +9,12 @@ const withMDX = createMDX({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Azure Static Web Apps configuration
-  output: 'export',
-  distDir: 'out',
+  // Azure Static Web Apps configuration - only in production
+  ...(process.env.NODE_ENV === 'production' && {
+    output: 'export',
+    distDir: 'out',
+  }),
+  
   trailingSlash: true,
   assetPrefix: process.env.NODE_ENV === 'production' ? '' : '',
   images: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "react-dom": "19.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -35,6 +36,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/topojson-client": "^3.1.5",
         "eslint": "^9",
         "eslint-config-next": "15.5.0",
         "tailwindcss": "^4",
@@ -2225,6 +2227,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -9054,6 +9077,26 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-dom": "19.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -38,6 +39,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/topojson-client": "^3.1.5",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
     "tailwindcss": "^4",

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -40,7 +40,10 @@ export default async function ArticlesPage({
 
   return (
     <>
-      <ArticleListStructuredData articles={articles} />
+      <ArticleListStructuredData articles={articles.map(article => ({
+        ...article,
+        id: article.slug
+      }))} />
       <div className="min-h-screen bg-green-pale">
         <Header />
 

--- a/src/app/[locale]/forecast/page.tsx
+++ b/src/app/[locale]/forecast/page.tsx
@@ -64,7 +64,7 @@ export default async function ForecastPage({
     }, {} as any);
 
   const parties = Object.values(latest).sort((a: any, b: any) => b.value - a.value);
-  const lastUpdate = new Date(parties[0].date).toLocaleDateString('en-US', {
+  const lastUpdate = new Date((parties[0] as any).date).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long', 
     day: 'numeric'
@@ -195,7 +195,7 @@ export default async function ForecastPage({
                         </span>
                       </div>
                       <span className="text-sm font-bold text-gray-900">
-                        {partyData ? (partyData.value * 100).toFixed(1) : '0.0'}%
+                        {partyData ? ((partyData as any).value * 100).toFixed(1) : '0.0'}%
                       </span>
                     </div>
                   );
@@ -228,7 +228,7 @@ export default async function ForecastPage({
                         </span>
                       </div>
                       <span className="text-sm font-bold text-gray-900">
-                        {partyData ? (partyData.value * 100).toFixed(1) : '0.0'}%
+                        {partyData ? ((partyData as any).value * 100).toFixed(1) : '0.0'}%
                       </span>
                     </div>
                   );

--- a/src/app/[locale]/map/page.tsx
+++ b/src/app/[locale]/map/page.tsx
@@ -1,0 +1,145 @@
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Header } from '@/components/Header';
+import MapPageClient from '@/components/MapPageClient';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import fs from 'fs';
+import path from 'path';
+
+interface DistrictForecast {
+  district_name: string;
+  winning_party: string;
+  probs: Record<string, number>;
+}
+
+async function getDistrictForecast(): Promise<DistrictForecast[]> {
+  try {
+    const filePath = path.join(process.cwd(), 'public', 'data', 'district_forecast.json');
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(fileContents);
+  } catch (error) {
+    console.error('Error loading district forecast:', error);
+    return [];
+  }
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Mapa Distrital - estimador.pt',
+    description: 'Mapa interativo com previsões eleitorais por distrito português',
+  };
+}
+
+export default async function MapPage() {
+  const t = await getTranslations();
+  const districtForecast = await getDistrictForecast();
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <Header />
+      
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-7xl mx-auto">
+          {/* Header */}
+          <div className="mb-8">
+            <h1 className="text-4xl font-bold text-slate-900 mb-4">
+              Mapa Distrital Interativo
+            </h1>
+            <p className="text-lg text-slate-600 max-w-3xl">
+              Explore as previsões eleitorais por distrito. Clique em qualquer distrito 
+              para ver a percentagem de votos prevista para cada partido.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            {/* Map */}
+            <div className="lg:col-span-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Portugal - Previsões por Distrito</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <MapPageClient districtForecast={districtForecast} />
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Sidebar */}
+            <div className="space-y-6">
+              {/* Legend */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Como Interpretar</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div>
+                    <h4 className="font-medium mb-2">Cores</h4>
+                    <p className="text-sm text-slate-600">
+                      Cada distrito está colorido com a cor do partido com maior 
+                      percentagem de votos prevista nessa região.
+                    </p>
+                  </div>
+                  <div>
+                    <h4 className="font-medium mb-2">Interação</h4>
+                    <p className="text-sm text-slate-600">
+                      Passe o rato sobre um distrito para ver o partido líder e percentagem, 
+                      ou clique para ver todos os detalhes.
+                    </p>
+                  </div>
+                  <div>
+                    <h4 className="font-medium mb-2">Ilhas</h4>
+                    <p className="text-sm text-slate-600">
+                      Os Açores e Madeira aparecem como múltiplas ilhas, mas as 
+                      previsões são agregadas por região.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Key Stats */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Estatísticas Gerais</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <MapStats districtForecast={districtForecast} />
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+// Component for map statistics
+function MapStats({ districtForecast }: { districtForecast: DistrictForecast[] }) {
+  const partyWins = districtForecast.reduce((acc, district) => {
+    acc[district.winning_party] = (acc[district.winning_party] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const sortedParties = Object.entries(partyWins)
+    .sort(([,a], [,b]) => b - a);
+
+  return (
+    <div className="space-y-3">
+      <h4 className="font-medium">Distritos Liderados:</h4>
+      <div className="space-y-2">
+        {sortedParties.map(([party, count]) => (
+          <div key={party} className="flex justify-between items-center">
+            <Badge variant="outline">{party}</Badge>
+            <span className="text-sm font-medium">{count}</span>
+          </div>
+        ))}
+      </div>
+      <div className="pt-3 border-t">
+        <p className="text-sm text-slate-600">
+          Total de distritos: {districtForecast.length}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,6 +13,7 @@ import { CoalitionDotPlot } from "@/components/charts/CoalitionDotPlot";
 import { SimpleCoalitionDots } from "@/components/charts/SimpleCoalitionDots";
 import DistrictMapPreview from "@/components/charts/DistrictMapPreview";
 import { Header } from "@/components/Header";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import type { Metadata } from 'next';
@@ -230,10 +231,12 @@ export default async function Home({
                 {t('homepage.districtDescription')}
               </p>
               <div className="w-full h-80 md:h-96">
-                <DistrictMapPreview 
-                  districtForecast={districtForecast}
-                  className="rounded overflow-hidden h-full"
-                />
+                <ErrorBoundary componentName="District Map Preview">
+                  <DistrictMapPreview 
+                    districtForecast={districtForecast}
+                    className="rounded overflow-hidden h-full"
+                  />
+                </ErrorBoundary>
               </div>
             </div>
           </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -11,6 +11,7 @@ import { ArrowRight, TrendingUp, BarChart3, Map, Users, Calendar } from "lucide-
 import { PollingChart } from "@/components/charts/PollingChart";
 import { CoalitionDotPlot } from "@/components/charts/CoalitionDotPlot";
 import { SimpleCoalitionDots } from "@/components/charts/SimpleCoalitionDots";
+import DistrictMapPreview from "@/components/charts/DistrictMapPreview";
 import { Header } from "@/components/Header";
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
@@ -46,6 +47,20 @@ export default async function Home({
   const { locale } = await params;
   const t = await getTranslations({ locale });
   const { seatData, nationalTrends } = await loadForecastData();
+  
+  // Load district forecast data for map preview
+  const districtForecast = await (async () => {
+    try {
+      const fs = await import('fs');
+      const path = await import('path');
+      const filePath = path.join(process.cwd(), 'public', 'data', 'district_forecast.json');
+      const fileContents = fs.readFileSync(filePath, 'utf8');
+      return JSON.parse(fileContents);
+    } catch (error) {
+      console.error('Error loading district forecast:', error);
+      return [];
+    }
+  })();
   
   // Calculate key probabilities
   const probLeftMajority = calculateBlocMajorityProbability(seatData, leftBlocParties, majorityThreshold);
@@ -190,17 +205,43 @@ export default async function Home({
             </div>
           </div>
 
-          {/* Charts Grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
+          {/* Content Grid with Map and Polling */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             
             {/* Polling Trends */}
-            <div className="lg:col-span-3 bg-white border border-gray-200 rounded-lg p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">{t('forecast.pollingTrends')}</h3>
+            <div className="lg:col-span-2 bg-white border border-gray-200 rounded-lg p-6">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">{t('forecast.pollingTrends')}</h2>
               <PollingChart data={nationalTrends} />
             </div>
 
+            {/* District Map */}
+            <div className="bg-white border border-gray-200 rounded-lg p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-semibold text-gray-900">{t('homepage.districtForecast')}</h2>
+                <Link 
+                  href="/map" 
+                  className="inline-flex items-center text-xs font-medium text-green-dark hover:text-green-medium transition-colors"
+                >
+                  {t('common.viewFull')}
+                  <ArrowRight className="w-3 h-3 ml-1" />
+                </Link>
+              </div>
+              <p className="text-xs text-gray-600 mb-4">
+                {t('homepage.districtDescription')}
+              </p>
+              <div className="w-full h-80 md:h-96">
+                <DistrictMapPreview 
+                  districtForecast={districtForecast}
+                  className="rounded overflow-hidden h-full"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Second row with current standings and coalition scenarios */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             {/* Current standings */}
-            <div className="lg:col-span-2 bg-white border border-gray-200 rounded-lg p-6">
+            <div className="bg-white border border-gray-200 rounded-lg p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">{t('homepage.currentStandings')}</h3>
               <div className="space-y-3">
                 {parties.slice(0, 6).map((party: any, index) => (
@@ -221,29 +262,29 @@ export default async function Home({
                   </div>
                 ))}
               </div>
-              
-              {/* Coalition scenarios in sidebar */}
-              <div className="mt-6 pt-6 border-t border-gray-200">
-                <h4 className="text-sm font-semibold text-gray-900 mb-3">{t('homepage.coalitionScenarios')}</h4>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-900">{t('homepage.rightMajority')}</span>
-                    <span className="text-lg font-bold text-gray-900">
-                      {formatProbabilityPercent(probRightMajority)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-900">{t('homepage.leftMajority')}</span>
-                    <span className="text-lg font-bold text-gray-900">
-                      {formatProbabilityPercent(probLeftMajority)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-900">{t('homepage.hungParliament')}</span>
-                    <span className="text-lg font-bold text-gray-900">
-                      {formatProbabilityPercent(1 - probRightMajority - probLeftMajority)}
-                    </span>
-                  </div>
+            </div>
+
+            {/* Coalition scenarios */}
+            <div className="bg-white border border-gray-200 rounded-lg p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">{t('homepage.coalitionScenarios')}</h3>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-gray-900">{t('homepage.rightMajority')}</span>
+                  <span className="text-2xl font-bold text-gray-900">
+                    {formatProbabilityPercent(probRightMajority)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-gray-900">{t('homepage.leftMajority')}</span>
+                  <span className="text-2xl font-bold text-gray-900">
+                    {formatProbabilityPercent(probLeftMajority)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-gray-900">{t('homepage.hungParliament')}</span>
+                  <span className="text-2xl font-bold text-gray-900">
+                    {formatProbabilityPercent(1 - probRightMajority - probLeftMajority)}
+                  </span>
                 </div>
               </div>
             </div>
@@ -263,6 +304,13 @@ export default async function Home({
               {t('nav.forecast')}
             </Link>
             <Link 
+              href="/map" 
+              className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-green-pale transition-colors"
+            >
+              <Map className="w-4 h-4 mr-2" />
+              Mapa Distrital
+            </Link>
+            <Link 
               href="/articles" 
               className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-green-pale transition-colors"
             >
@@ -273,7 +321,7 @@ export default async function Home({
               href="/methodology" 
               className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-green-pale transition-colors"
             >
-              <Map className="w-4 h-4 mr-2" />
+              <Users className="w-4 h-4 mr-2" />
               {t('common.methodology')}
             </Link>
           </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  componentName?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+/**
+ * Error Boundary component for React error handling
+ * Provides graceful fallback UI when component errors occur
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Error caught by ErrorBoundary:', error, errorInfo);
+    
+    // In production, you might want to log this to an error reporting service
+    if (process.env.NODE_ENV === 'production') {
+      // Example: logErrorToService(error, errorInfo);
+    }
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      // Custom fallback UI or default error message
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center p-8 bg-red-50 border border-red-200 rounded-lg">
+          <AlertTriangle className="w-8 h-8 text-red-500 mb-4" />
+          <h3 className="text-lg font-semibold text-red-800 mb-2">
+            Something went wrong
+          </h3>
+          <p className="text-red-600 text-center mb-4">
+            {this.props.componentName 
+              ? `Failed to load ${this.props.componentName}` 
+              : 'An error occurred while rendering this component'
+            }
+          </p>
+          <button
+            onClick={() => this.setState({ hasError: false, error: undefined })}
+            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * Higher-order component to wrap components with error boundary
+ */
+export function withErrorBoundary<T extends {}>(
+  Component: React.ComponentType<T>,
+  componentName?: string,
+  fallback?: ReactNode
+) {
+  const WrappedComponent = (props: T) => (
+    <ErrorBoundary componentName={componentName} fallback={fallback}>
+      <Component {...props} />
+    </ErrorBoundary>
+  );
+
+  WrappedComponent.displayName = `withErrorBoundary(${Component.displayName || Component.name})`;
+  
+  return WrappedComponent;
+}
+
+/**
+ * Map-specific error boundary with tailored error message
+ */
+export function MapErrorBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary
+      componentName="Interactive Map"
+      fallback={
+        <div className="flex flex-col items-center justify-center p-8 bg-gray-50 border border-gray-200 rounded-lg min-h-[400px]">
+          <AlertTriangle className="w-12 h-12 text-gray-400 mb-4" />
+          <h3 className="text-xl font-semibold text-gray-700 mb-2">
+            Map Loading Error
+          </h3>
+          <p className="text-gray-600 text-center mb-4 max-w-md">
+            Unable to load the interactive district map. This might be due to a network issue or browser compatibility problem.
+          </p>
+          <div className="text-sm text-gray-500">
+            Please try refreshing the page or use a different browser.
+          </div>
+        </div>
+      }
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,12 +14,14 @@ export function Header() {
     if (pathname === '/about') return t('about.title');
     if (pathname === '/articles') return t('articles.title');
     if (pathname === '/methodology') return t('methodology.title');
+    if (pathname === '/map') return 'Mapa Distrital';
     return '';
   };
 
   const navigationItems = [
     { href: '/', label: t('nav.home') },
     { href: '/forecast', label: t('nav.forecast') },
+    { href: '/map', label: 'Mapa' },
     { href: '/articles', label: t('nav.analysis') },
     { href: '/about', label: t('nav.about') },
   ];

--- a/src/components/MapPageClient.tsx
+++ b/src/components/MapPageClient.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import DistrictMap from '@/components/charts/DistrictMap';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { partyColors } from '@/lib/config/colors';
+import { MapErrorBoundary } from '@/components/ErrorBoundary';
 
 interface DistrictForecast {
   district_name: string;
@@ -19,6 +21,7 @@ interface MapPageClientProps {
 export default function MapPageClient({ districtForecast }: MapPageClientProps) {
   const [selectedDistrict, setSelectedDistrict] = useState<string | null>(null);
   const [selectedData, setSelectedData] = useState<{ id: string; probs: Record<string, number> } | null>(null);
+  const t = useTranslations('map');
 
   const handleDistrictClick = (district: { id: string; probs: Record<string, number> }) => {
     setSelectedDistrict(district.id);
@@ -27,12 +30,14 @@ export default function MapPageClient({ districtForecast }: MapPageClientProps) 
 
   return (
     <div className="space-y-6">
-      <DistrictMap
-        districtForecast={districtForecast}
-        onDistrictClick={handleDistrictClick}
-        selectedDistrict={selectedDistrict}
-        className="border rounded-lg"
-      />
+      <MapErrorBoundary>
+        <DistrictMap
+          districtForecast={districtForecast}
+          onDistrictClick={handleDistrictClick}
+          selectedDistrict={selectedDistrict}
+          className="border rounded-lg"
+        />
+      </MapErrorBoundary>
       
       {/* Selected District Details */}
       {selectedData && (
@@ -42,7 +47,7 @@ export default function MapPageClient({ districtForecast }: MapPageClientProps) 
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              <h4 className="font-medium">Previsão de Votos por Partido:</h4>
+              <h4 className="font-medium">{t('voteShareByParty')}:</h4>
               <div className="space-y-3">
                 {Object.entries(selectedData.probs)
                   .sort(([,a], [,b]) => b - a)

--- a/src/components/MapPageClient.tsx
+++ b/src/components/MapPageClient.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import DistrictMap from '@/components/charts/DistrictMap';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { partyColors } from '@/lib/config/colors';
+
+interface DistrictForecast {
+  district_name: string;
+  winning_party: string;
+  probs: Record<string, number>;
+}
+
+interface MapPageClientProps {
+  districtForecast: DistrictForecast[];
+}
+
+export default function MapPageClient({ districtForecast }: MapPageClientProps) {
+  const [selectedDistrict, setSelectedDistrict] = useState<string | null>(null);
+  const [selectedData, setSelectedData] = useState<{ id: string; probs: Record<string, number> } | null>(null);
+
+  const handleDistrictClick = (district: { id: string; probs: Record<string, number> }) => {
+    setSelectedDistrict(district.id);
+    setSelectedData(district);
+  };
+
+  return (
+    <div className="space-y-6">
+      <DistrictMap
+        districtForecast={districtForecast}
+        onDistrictClick={handleDistrictClick}
+        selectedDistrict={selectedDistrict}
+        className="border rounded-lg"
+      />
+      
+      {/* Selected District Details */}
+      {selectedData && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{selectedData.id}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <h4 className="font-medium">Previsão de Votos por Partido:</h4>
+              <div className="space-y-3">
+                {Object.entries(selectedData.probs)
+                  .sort(([,a], [,b]) => b - a)
+                  .map(([party, share]) => {
+                    const percentage = (share * 100);
+                    return (
+                      <div key={party} className="space-y-1">
+                        <div className="flex justify-between items-center">
+                          <Badge 
+                            variant="outline" 
+                            className="text-xs font-medium"
+                            style={{ 
+                              backgroundColor: `${partyColors[party] || '#e5e7eb'}20`,
+                              borderColor: partyColors[party] || '#e5e7eb'
+                            }}
+                          >
+                            {party}
+                          </Badge>
+                          <span className="text-sm font-medium">
+                            {percentage.toFixed(1)}%
+                          </span>
+                        </div>
+                        <div className="w-full bg-gray-200 rounded-full h-2">
+                          <div 
+                            className="h-2 rounded-full transition-all duration-300"
+                            style={{ 
+                              width: `${percentage}%`,
+                              backgroundColor: partyColors[party] || '#e5e7eb'
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+              </div>
+              <div className="pt-2 border-t text-xs text-gray-600">
+                <p>Percentagem de votos prevista para cada partido neste distrito</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/charts/ChartEmbed.tsx
+++ b/src/components/charts/ChartEmbed.tsx
@@ -8,27 +8,27 @@ import { Suspense } from 'react';
 const PollingChart = dynamic(() => import('./PollingChart'), { 
   ssr: false,
   loading: () => <ChartSkeleton />
-});
+}) as any;
 
 const SeatChart = dynamic(() => import('./seat-projection'), { 
   ssr: false,
   loading: () => <ChartSkeleton />
-});
+}) as any;
 
 const CoalitionDotPlot = dynamic(() => import('./CoalitionDotPlot'), { 
   ssr: false,
   loading: () => <ChartSkeleton />
-});
+}) as any;
 
 const HouseEffects = dynamic(() => import('./HouseEffects'), { 
   ssr: false,
   loading: () => <ChartSkeleton />
-});
+}) as any;
 
 const DistrictSummary = dynamic(() => import('./DistrictSummary'), { 
   ssr: false,
   loading: () => <ChartSkeleton />
-});
+}) as any;
 
 function ChartSkeleton() {
   return (

--- a/src/components/charts/DistrictMap.tsx
+++ b/src/components/charts/DistrictMap.tsx
@@ -5,17 +5,19 @@ import * as Plot from '@observablehq/plot';
 import * as d3 from 'd3';
 import * as topojson from 'topojson-client';
 import { partyColors, partyOrder } from '@/lib/config/colors';
-
-interface DistrictForecast {
-  district_name: string;
-  winning_party: string;
-  probs: Record<string, number>;
-}
+import type { 
+  DistrictForecast, 
+  PortugalTopoJSON, 
+  DistrictFeatureCollection,
+  GeometryDataMap,
+  SelectedDistrict,
+  RegionMapper
+} from '@/types/geography';
 
 interface DistrictMapProps {
   districtForecast: DistrictForecast[];
   className?: string;
-  onDistrictClick?: (district: { id: string; probs: Record<string, number> }) => void;
+  onDistrictClick?: (district: SelectedDistrict) => void;
   selectedDistrict?: string | null;
 }
 

--- a/src/components/charts/DistrictMap.tsx
+++ b/src/components/charts/DistrictMap.tsx
@@ -5,13 +5,13 @@ import * as Plot from '@observablehq/plot';
 import * as d3 from 'd3';
 import * as topojson from 'topojson-client';
 import { partyColors, partyOrder } from '@/lib/config/colors';
+import { getRegionForIsland } from '@/lib/geography/regionMapping';
 import type { 
   DistrictForecast, 
   PortugalTopoJSON, 
   DistrictFeatureCollection,
   GeometryDataMap,
-  SelectedDistrict,
-  RegionMapper
+  SelectedDistrict
 } from '@/types/geography';
 
 interface DistrictMapProps {
@@ -21,19 +21,6 @@ interface DistrictMapProps {
   selectedDistrict?: string | null;
 }
 
-// Function to identify island geometries belonging to aggregated regions
-function getRegionForIsland(islandName: string): string {
-  const azoresIslands = [
-    "Ilha do Faial", "Ilha de São Jorge", "Ilha da Graciosa", "Ilha Terceira", 
-    "Ilha das Flores", "Ilha do Corvo", "Ilha de São Miguel", "Ilha de Santa Maria", "Ilha do Pico"
-  ];
-  const madeiraIslands = ["Ilha da Madeira", "Ilha de Porto Santo"];
-
-  if (azoresIslands.includes(islandName)) return "Açores";
-  if (madeiraIslands.includes(islandName)) return "Madeira";
-  return islandName; // If not an island, return the name itself (continental district)
-}
-
 export default function DistrictMap({ 
   districtForecast, 
   className = '', 
@@ -41,7 +28,7 @@ export default function DistrictMap({
   selectedDistrict 
 }: DistrictMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [portugalTopoJson, setPortugalTopoJson] = useState<any>(null);
+  const [portugalTopoJson, setPortugalTopoJson] = useState<PortugalTopoJSON | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tooltip, setTooltip] = useState<{

--- a/src/components/charts/DistrictMap.tsx
+++ b/src/components/charts/DistrictMap.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import React, { useRef, useEffect, useState } from 'react';
+import * as Plot from '@observablehq/plot';
+import * as d3 from 'd3';
+import * as topojson from 'topojson-client';
+import { partyColors, partyOrder } from '@/lib/config/colors';
+
+interface DistrictForecast {
+  district_name: string;
+  winning_party: string;
+  probs: Record<string, number>;
+}
+
+interface DistrictMapProps {
+  districtForecast: DistrictForecast[];
+  className?: string;
+  onDistrictClick?: (district: { id: string; probs: Record<string, number> }) => void;
+  selectedDistrict?: string | null;
+}
+
+// Function to identify island geometries belonging to aggregated regions
+function getRegionForIsland(islandName: string): string {
+  const azoresIslands = [
+    "Ilha do Faial", "Ilha de São Jorge", "Ilha da Graciosa", "Ilha Terceira", 
+    "Ilha das Flores", "Ilha do Corvo", "Ilha de São Miguel", "Ilha de Santa Maria", "Ilha do Pico"
+  ];
+  const madeiraIslands = ["Ilha da Madeira", "Ilha de Porto Santo"];
+
+  if (azoresIslands.includes(islandName)) return "Açores";
+  if (madeiraIslands.includes(islandName)) return "Madeira";
+  return islandName; // If not an island, return the name itself (continental district)
+}
+
+export default function DistrictMap({ 
+  districtForecast, 
+  className = '', 
+  onDistrictClick,
+  selectedDistrict 
+}: DistrictMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [portugalTopoJson, setPortugalTopoJson] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<{
+    show: boolean;
+    x: number;
+    y: number;
+    content: string;
+  }>({ show: false, x: 0, y: 0, content: '' });
+
+  // Load TopoJSON data
+  useEffect(() => {
+    async function loadTopoJson() {
+      try {
+        const response = await fetch('/data/Portugal-Distritos-Ilhas_TopoJSON.json');
+        if (!response.ok) {
+          throw new Error('Failed to load TopoJSON data');
+        }
+        const data = await response.json();
+        setPortugalTopoJson(data);
+        setIsLoading(false);
+      } catch (err) {
+        console.error('Error loading TopoJSON:', err);
+        setError('Failed to load map data');
+        setIsLoading(false);
+      }
+    }
+
+    loadTopoJson();
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current || !portugalTopoJson || !districtForecast || isLoading) {
+      return;
+    }
+
+    const container = containerRef.current;
+    
+    // Clear previous content
+    container.innerHTML = '';
+
+    try {
+      // Extract features from TopoJSON
+      const districts = topojson.feature(portugalTopoJson, portugalTopoJson.objects.ilhasGeo2);
+      
+      if (!districts || !districts.features || districts.features.length === 0) {
+        console.error('No valid districts features found in TopoJSON');
+        return;
+      }
+
+      // Process forecast data to find the winning party per district/region
+      const normalizedForecast = districtForecast.map(d => ({
+        ...d,
+        district_name: d.district_name === "Açores" ? "Açores" : d.district_name
+      }));
+
+      const forecastByDistrict = d3.group(normalizedForecast, d => d.district_name);
+      const winningParty = new Map<string, string>();
+      const districtProbs = new Map<string, Record<string, number>>();
+
+      // Extract winning party and probabilities for each district
+      for (const [districtName, forecastEntries] of forecastByDistrict) {
+        if (forecastEntries && forecastEntries.length > 0) {
+          const districtData = forecastEntries[0];
+          districtProbs.set(districtName, districtData.probs || {});
+          winningParty.set(districtName, districtData.winning_party || 'default');
+        } else {
+          districtProbs.set(districtName, {});
+          winningParty.set(districtName, 'default');
+        }
+      }
+
+      // Create geometry data map
+      const geometryDataMap = new Map<string, { winner: string; forecast: Record<string, number> }>();
+      
+      for (const feature of districts.features) {
+        const geometryName = feature.properties.NAME_1;
+        const regionOrDistrictName = getRegionForIsland(geometryName);
+        const winnerForRegion = winningParty.get(regionOrDistrictName);
+        const actualProbs = districtProbs.get(regionOrDistrictName) || {};
+
+        geometryDataMap.set(geometryName, {
+          winner: winnerForRegion || 'default',
+          forecast: actualProbs
+        });
+      }
+
+      // Get container width for responsive sizing
+      const containerWidth = containerRef.current.offsetWidth;
+
+      // Create the Plot
+      const plot = Plot.plot({
+        width: containerWidth,
+        height: Math.min(500, containerWidth * 0.8), // Responsive height
+        projection: {
+          type: "mercator",
+          domain: districts,
+        },
+        color: {
+          domain: partyOrder.filter(p => p !== 'OTH'),
+          range: partyOrder.filter(p => p !== 'OTH').map(p => partyColors[p] || "#888888"),
+          legend: true,
+          label: "Partido vencedor"
+        },
+        marks: [
+          Plot.geo(districts, {
+            fill: (d: any) => {
+              const data = geometryDataMap.get(d.properties.NAME_1);
+              return partyColors[data?.winner] || "#e5e7eb";
+            },
+            stroke: "white",
+            strokeWidth: 0.5,
+            cursor: "pointer",
+            // Remove title for now - we'll handle tooltips manually
+          })
+        ]
+      });
+
+      // Add event listeners for click and hover
+      plot.addEventListener("click", (event: any) => {
+        const target = event.target;
+        if (!target || typeof target.__data__ !== 'number') return;
+
+        const featureIndex = target.__data__;
+        if (featureIndex >= 0 && featureIndex < districts.features.length) {
+          const clickedFeature = districts.features[featureIndex];
+          const clickedFeatureKey = clickedFeature?.properties?.NAME_1;
+          
+          if (clickedFeatureKey) {
+            const data = geometryDataMap.get(clickedFeatureKey);
+            const regionName = getRegionForIsland(clickedFeatureKey);
+            
+            if (onDistrictClick && data) {
+              onDistrictClick({
+                id: regionName,
+                probs: data.forecast
+              });
+            }
+          }
+        }
+      });
+
+      // Add mouseover event listener
+      plot.addEventListener("mouseover", (event: any) => {
+        const target = event.target;
+        if (!target || typeof target.__data__ !== 'number') return;
+
+        const featureIndex = target.__data__;
+        if (featureIndex >= 0 && featureIndex < districts.features.length) {
+          const feature = districts.features[featureIndex];
+          const geometryName = feature?.properties?.NAME_1;
+          
+          if (geometryName) {
+            const regionName = getRegionForIsland(geometryName);
+            const data = geometryDataMap.get(geometryName);
+            const winner = data?.winner || 'N/A';
+            const percentage = data?.forecast[winner] || 0;
+            
+            const rect = containerRef.current?.getBoundingClientRect();
+            if (rect) {
+              setTooltip({
+                show: true,
+                x: event.clientX - rect.left,
+                y: event.clientY - rect.top,
+                content: `${regionName}\nLíder: ${winner}\nVotos: ${(percentage * 100).toFixed(1)}%`
+              });
+            }
+          }
+        }
+      });
+
+      // Add mouseout event listener
+      plot.addEventListener("mouseout", () => {
+        setTooltip({ show: false, x: 0, y: 0, content: '' });
+      });
+
+      container.appendChild(plot);
+
+      // Cleanup function
+      return () => {
+        // More robust cleanup
+        try {
+          if (container && container.contains(plot)) {
+            container.removeChild(plot);
+          } else if (container) {
+            container.innerHTML = '';
+          }
+        } catch (error) {
+          // Fallback to clearing innerHTML if removeChild fails
+          if (container) {
+            container.innerHTML = '';
+          }
+        }
+      };
+
+    } catch (err) {
+      console.error('Error creating district map:', err);
+      setError('Failed to create map visualization');
+    }
+  }, [portugalTopoJson, districtForecast, isLoading]);
+
+  // Handle district selection highlighting
+  useEffect(() => {
+    if (!containerRef.current || !portugalTopoJson) return;
+
+    try {
+      // Extract features to match path indices
+      const districts = topojson.feature(portugalTopoJson, portugalTopoJson.objects.ilhasGeo2);
+      const paths = containerRef.current.querySelectorAll("path");
+      
+      paths.forEach((path: Element, i: number) => {
+        const pathElement = path as HTMLElement;
+        if (i < districts.features.length) {
+          const feature = districts.features[i];
+          const geometryName = feature?.properties?.NAME_1;
+          const regionName = getRegionForIsland(geometryName);
+          
+          if (regionName === selectedDistrict) {
+            pathElement.style.strokeWidth = "2";
+            pathElement.style.stroke = "white";
+          } else {
+            pathElement.style.strokeWidth = "0.5";
+            pathElement.style.stroke = "white";
+          }
+        }
+      });
+    } catch (err) {
+      console.error('Error updating district highlighting:', err);
+    }
+  }, [selectedDistrict, portugalTopoJson]);
+
+  // Handle resize
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Trigger re-render when container size changes
+      if (portugalTopoJson && districtForecast && !isLoading) {
+        // Force re-render by updating a dependency
+        const event = new Event('resize');
+        window.dispatchEvent(event);
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [portugalTopoJson, districtForecast, isLoading]);
+
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center h-96 ${className}`}>
+        <div className="text-gray-500">A carregar mapa...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={`flex items-center justify-center h-96 ${className}`}>
+        <div className="text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div 
+      ref={containerRef} 
+      className={`w-full relative ${className}`}
+      style={{ minHeight: '400px' }}
+    >
+      {/* Custom Tooltip */}
+      {tooltip.show && (
+        <div
+          className="absolute z-10 bg-black text-white text-xs rounded px-2 py-1 pointer-events-none"
+          style={{
+            left: tooltip.x + 10,
+            top: tooltip.y - 10,
+            whiteSpace: 'pre-line'
+          }}
+        >
+          {tooltip.content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/charts/DistrictMapPreview.tsx
+++ b/src/components/charts/DistrictMapPreview.tsx
@@ -1,34 +1,21 @@
 'use client';
 
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import * as Plot from '@observablehq/plot';
-import * as d3 from 'd3';
 import * as topojson from 'topojson-client';
 import { partyColors } from '@/lib/config/colors';
-
-interface DistrictForecast {
-  district_name: string;
-  winning_party: string;
-  probs: Record<string, number>;
-}
+import { useTopoJsonData } from '@/hooks/useTopoJsonData';
+import { useDistrictData, useGeometryDataMap, getRegionForIsland } from '@/hooks/useDistrictData';
+import { useTooltip } from '@/hooks/useTooltip';
+import type { 
+  DistrictForecast, 
+  DistrictFeatureCollection
+} from '@/types/geography';
 
 interface DistrictMapPreviewProps {
   districtForecast: DistrictForecast[];
   className?: string;
   height?: number;
-}
-
-// Function to identify island geometries belonging to aggregated regions
-function getRegionForIsland(islandName: string): string {
-  const azoresIslands = [
-    "Ilha do Faial", "Ilha de São Jorge", "Ilha da Graciosa", "Ilha Terceira", 
-    "Ilha das Flores", "Ilha do Corvo", "Ilha de São Miguel", "Ilha de Santa Maria", "Ilha do Pico"
-  ];
-  const madeiraIslands = ["Ilha da Madeira", "Ilha de Porto Santo"];
-
-  if (azoresIslands.includes(islandName)) return "Açores";
-  if (madeiraIslands.includes(islandName)) return "Madeira";
-  return islandName; // If not an island, return the name itself (continental district)
 }
 
 export default function DistrictMapPreview({ 
@@ -37,39 +24,26 @@ export default function DistrictMapPreview({
   height = 300 
 }: DistrictMapPreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [portugalTopoJson, setPortugalTopoJson] = useState<any>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [tooltip, setTooltip] = useState<{
-    show: boolean;
-    x: number;
-    y: number;
-    content: string;
-  }>({ show: false, x: 0, y: 0, content: '' });
+  
+  // Use custom hooks
+  const { portugalTopoJson, isLoading, error } = useTopoJsonData();
+  const { winningParty, districtProbs } = useDistrictData(districtForecast);
+  const { tooltip, showTooltip, hideTooltip } = useTooltip();
 
-  // Load TopoJSON data
-  useEffect(() => {
-    async function loadTopoJson() {
-      try {
-        const response = await fetch('/data/Portugal-Distritos-Ilhas_TopoJSON.json');
-        if (!response.ok) {
-          throw new Error('Failed to load TopoJSON data');
-        }
-        const data = await response.json();
-        setPortugalTopoJson(data);
-        setIsLoading(false);
-      } catch (err) {
-        console.error('Error loading TopoJSON:', err);
-        setError('Failed to load map data');
-        setIsLoading(false);
-      }
-    }
-
-    loadTopoJson();
-  }, []);
+  // Extract features and create geometry data map
+  const districts = portugalTopoJson ? 
+    topojson.feature(portugalTopoJson, portugalTopoJson.objects.ilhasGeo2) as DistrictFeatureCollection : 
+    null;
+  
+  // Always call the hook, but pass empty array if no districts
+  const geometryDataMap = useGeometryDataMap(
+    districts?.features || [], 
+    winningParty, 
+    districtProbs
+  );
 
   useEffect(() => {
-    if (!containerRef.current || !portugalTopoJson || !districtForecast || isLoading) {
+    if (!containerRef.current || !portugalTopoJson || !districtForecast || isLoading || !districts) {
       return;
     }
 
@@ -79,49 +53,9 @@ export default function DistrictMapPreview({
     container.innerHTML = '';
 
     try {
-      // Extract features from TopoJSON
-      const districts = topojson.feature(portugalTopoJson, portugalTopoJson.objects.ilhasGeo2);
-      
       if (!districts || !districts.features || districts.features.length === 0) {
         console.error('No valid districts features found in TopoJSON');
         return;
-      }
-
-      // Process forecast data to find the winning party per district/region
-      const normalizedForecast = districtForecast.map(d => ({
-        ...d,
-        district_name: d.district_name === "Açores" ? "Açores" : d.district_name
-      }));
-
-      const forecastByDistrict = d3.group(normalizedForecast, d => d.district_name);
-      const winningParty = new Map<string, string>();
-      const districtProbs = new Map<string, Record<string, number>>();
-
-      // Extract winning party and probabilities for each district
-      for (const [districtName, forecastEntries] of forecastByDistrict) {
-        if (forecastEntries && forecastEntries.length > 0) {
-          const districtData = forecastEntries[0];
-          districtProbs.set(districtName, districtData.probs || {});
-          winningParty.set(districtName, districtData.winning_party || 'default');
-        } else {
-          districtProbs.set(districtName, {});
-          winningParty.set(districtName, 'default');
-        }
-      }
-
-      // Create geometry data map
-      const geometryDataMap = new Map<string, { winner: string; forecast: Record<string, number> }>();
-      
-      for (const feature of districts.features) {
-        const geometryName = feature.properties.NAME_1;
-        const regionOrDistrictName = getRegionForIsland(geometryName);
-        const winnerForRegion = winningParty.get(regionOrDistrictName);
-        const actualProbs = districtProbs.get(regionOrDistrictName) || {};
-
-        geometryDataMap.set(geometryName, {
-          winner: winnerForRegion || 'default',
-          forecast: actualProbs
-        });
       }
 
       // Get container dimensions for responsive sizing
@@ -167,29 +101,14 @@ export default function DistrictMapPreview({
             const data = geometryDataMap.get(geometryName);
             
             if (data?.forecast) {
-              const parties = Object.entries(data.forecast)
-                .filter(([party]) => partyColors.hasOwnProperty(party))
-                .sort(([,a], [,b]) => b - a)
-                .slice(0, 3);
-              
               const rect = containerRef.current?.getBoundingClientRect();
-              if (rect && parties.length > 0) {
-                const tooltipContent = `
-                  <div class="font-semibold text-sm mb-2">${regionName}</div>
-                  ${parties.map(([party, percentage]) => 
-                    `<div class="flex items-center justify-between text-xs">
-                      <span>${party}</span>
-                      <span class="font-medium">${(percentage * 100).toFixed(1)}%</span>
-                    </div>`
-                  ).join('')}
-                `;
-                
-                setTooltip({
-                  show: true,
-                  x: event.clientX - rect.left,
-                  y: event.clientY - rect.top,
-                  content: tooltipContent
-                });
+              if (rect) {
+                showTooltip(
+                  event.clientX - rect.left,
+                  event.clientY - rect.top,
+                  regionName,
+                  data.forecast
+                );
               }
             }
           }
@@ -198,7 +117,7 @@ export default function DistrictMapPreview({
 
       // Add mouseout event listener
       plot.addEventListener("mouseout", () => {
-        setTooltip({ show: false, x: 0, y: 0, content: '' });
+        hideTooltip();
       });
 
       // Cleanup function
@@ -218,9 +137,8 @@ export default function DistrictMapPreview({
 
     } catch (err) {
       console.error('Error creating district map preview:', err);
-      setError('Failed to create map visualization');
     }
-  }, [portugalTopoJson, districtForecast, isLoading, height]);
+  }, [portugalTopoJson, districtForecast, isLoading, height, districts, geometryDataMap, showTooltip, hideTooltip]);
 
   if (isLoading) {
     return (
@@ -246,7 +164,7 @@ export default function DistrictMapPreview({
       />
       
       {/* Tooltip */}
-      {tooltip.show && (
+      {tooltip.show && tooltip.content && (
         <div
           className="absolute z-10 bg-white border border-gray-200 rounded-lg shadow-lg p-3 pointer-events-none"
           style={{
@@ -254,8 +172,15 @@ export default function DistrictMapPreview({
             top: tooltip.y - 10,
             transform: tooltip.x > 200 ? 'translateX(-100%)' : 'none'
           }}
-          dangerouslySetInnerHTML={{ __html: tooltip.content }}
-        />
+        >
+          <div className="font-semibold text-sm mb-2">{tooltip.content.regionName}</div>
+          {tooltip.content.parties.map(([party, percentage]) => (
+            <div key={party} className="flex items-center justify-between text-xs">
+              <span>{party}</span>
+              <span className="font-medium">{(percentage * 100).toFixed(1)}%</span>
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/components/charts/DistrictMapPreview.tsx
+++ b/src/components/charts/DistrictMapPreview.tsx
@@ -5,8 +5,9 @@ import * as Plot from '@observablehq/plot';
 import * as topojson from 'topojson-client';
 import { partyColors } from '@/lib/config/colors';
 import { useTopoJsonData } from '@/hooks/useTopoJsonData';
-import { useDistrictData, useGeometryDataMap, getRegionForIsland } from '@/hooks/useDistrictData';
+import { useDistrictData, useGeometryDataMap } from '@/hooks/useDistrictData';
 import { useTooltip } from '@/hooks/useTooltip';
+import { getRegionForIsland } from '@/lib/geography/regionMapping';
 import type { 
   DistrictForecast, 
   DistrictFeatureCollection

--- a/src/components/charts/DistrictMapPreview.tsx
+++ b/src/components/charts/DistrictMapPreview.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import React, { useRef, useEffect, useState } from 'react';
+import * as Plot from '@observablehq/plot';
+import * as d3 from 'd3';
+import * as topojson from 'topojson-client';
+import { partyColors } from '@/lib/config/colors';
+
+interface DistrictForecast {
+  district_name: string;
+  winning_party: string;
+  probs: Record<string, number>;
+}
+
+interface DistrictMapPreviewProps {
+  districtForecast: DistrictForecast[];
+  className?: string;
+  height?: number;
+}
+
+// Function to identify island geometries belonging to aggregated regions
+function getRegionForIsland(islandName: string): string {
+  const azoresIslands = [
+    "Ilha do Faial", "Ilha de São Jorge", "Ilha da Graciosa", "Ilha Terceira", 
+    "Ilha das Flores", "Ilha do Corvo", "Ilha de São Miguel", "Ilha de Santa Maria", "Ilha do Pico"
+  ];
+  const madeiraIslands = ["Ilha da Madeira", "Ilha de Porto Santo"];
+
+  if (azoresIslands.includes(islandName)) return "Açores";
+  if (madeiraIslands.includes(islandName)) return "Madeira";
+  return islandName; // If not an island, return the name itself (continental district)
+}
+
+export default function DistrictMapPreview({ 
+  districtForecast, 
+  className = '',
+  height = 300 
+}: DistrictMapPreviewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [portugalTopoJson, setPortugalTopoJson] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<{
+    show: boolean;
+    x: number;
+    y: number;
+    content: string;
+  }>({ show: false, x: 0, y: 0, content: '' });
+
+  // Load TopoJSON data
+  useEffect(() => {
+    async function loadTopoJson() {
+      try {
+        const response = await fetch('/data/Portugal-Distritos-Ilhas_TopoJSON.json');
+        if (!response.ok) {
+          throw new Error('Failed to load TopoJSON data');
+        }
+        const data = await response.json();
+        setPortugalTopoJson(data);
+        setIsLoading(false);
+      } catch (err) {
+        console.error('Error loading TopoJSON:', err);
+        setError('Failed to load map data');
+        setIsLoading(false);
+      }
+    }
+
+    loadTopoJson();
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current || !portugalTopoJson || !districtForecast || isLoading) {
+      return;
+    }
+
+    const container = containerRef.current;
+    
+    // Clear previous content
+    container.innerHTML = '';
+
+    try {
+      // Extract features from TopoJSON
+      const districts = topojson.feature(portugalTopoJson, portugalTopoJson.objects.ilhasGeo2);
+      
+      if (!districts || !districts.features || districts.features.length === 0) {
+        console.error('No valid districts features found in TopoJSON');
+        return;
+      }
+
+      // Process forecast data to find the winning party per district/region
+      const normalizedForecast = districtForecast.map(d => ({
+        ...d,
+        district_name: d.district_name === "Açores" ? "Açores" : d.district_name
+      }));
+
+      const forecastByDistrict = d3.group(normalizedForecast, d => d.district_name);
+      const winningParty = new Map<string, string>();
+      const districtProbs = new Map<string, Record<string, number>>();
+
+      // Extract winning party and probabilities for each district
+      for (const [districtName, forecastEntries] of forecastByDistrict) {
+        if (forecastEntries && forecastEntries.length > 0) {
+          const districtData = forecastEntries[0];
+          districtProbs.set(districtName, districtData.probs || {});
+          winningParty.set(districtName, districtData.winning_party || 'default');
+        } else {
+          districtProbs.set(districtName, {});
+          winningParty.set(districtName, 'default');
+        }
+      }
+
+      // Create geometry data map
+      const geometryDataMap = new Map<string, { winner: string; forecast: Record<string, number> }>();
+      
+      for (const feature of districts.features) {
+        const geometryName = feature.properties.NAME_1;
+        const regionOrDistrictName = getRegionForIsland(geometryName);
+        const winnerForRegion = winningParty.get(regionOrDistrictName);
+        const actualProbs = districtProbs.get(regionOrDistrictName) || {};
+
+        geometryDataMap.set(geometryName, {
+          winner: winnerForRegion || 'default',
+          forecast: actualProbs
+        });
+      }
+
+      // Get container dimensions for responsive sizing
+      const containerWidth = containerRef.current.offsetWidth;
+      const containerHeight = containerRef.current.offsetHeight || height;
+
+      // Create the Plot (simplified for preview)
+      const plot = Plot.plot({
+        width: containerWidth,
+        height: containerHeight,
+        projection: {
+          type: "mercator",
+          domain: districts,
+        },
+        // No legend for preview version  
+        marks: [
+          Plot.geo(districts, {
+            fill: (d: any) => {
+              const data = geometryDataMap.get(d.properties.NAME_1);
+              return partyColors[data?.winner] || "#e5e7eb";
+            },
+            stroke: "white",
+            strokeWidth: 0.5,
+            cursor: "pointer",
+          })
+        ]
+      });
+
+      container.appendChild(plot);
+
+      // Add mouseover event listener (same pattern as working DistrictMap)
+      plot.addEventListener("mouseover", (event: any) => {
+        const target = event.target;
+        if (!target || typeof target.__data__ !== 'number') return;
+
+        const featureIndex = target.__data__;
+        if (featureIndex >= 0 && featureIndex < districts.features.length) {
+          const feature = districts.features[featureIndex];
+          const geometryName = feature?.properties?.NAME_1;
+          
+          if (geometryName) {
+            const regionName = getRegionForIsland(geometryName);
+            const data = geometryDataMap.get(geometryName);
+            
+            if (data?.forecast) {
+              const parties = Object.entries(data.forecast)
+                .filter(([party]) => partyColors.hasOwnProperty(party))
+                .sort(([,a], [,b]) => b - a)
+                .slice(0, 3);
+              
+              const rect = containerRef.current?.getBoundingClientRect();
+              if (rect && parties.length > 0) {
+                const tooltipContent = `
+                  <div class="font-semibold text-sm mb-2">${regionName}</div>
+                  ${parties.map(([party, percentage]) => 
+                    `<div class="flex items-center justify-between text-xs">
+                      <span>${party}</span>
+                      <span class="font-medium">${(percentage * 100).toFixed(1)}%</span>
+                    </div>`
+                  ).join('')}
+                `;
+                
+                setTooltip({
+                  show: true,
+                  x: event.clientX - rect.left,
+                  y: event.clientY - rect.top,
+                  content: tooltipContent
+                });
+              }
+            }
+          }
+        }
+      });
+
+      // Add mouseout event listener
+      plot.addEventListener("mouseout", () => {
+        setTooltip({ show: false, x: 0, y: 0, content: '' });
+      });
+
+      // Cleanup function
+      return () => {
+        try {
+          if (container && container.contains(plot)) {
+            container.removeChild(plot);
+          } else if (container) {
+            container.innerHTML = '';
+          }
+        } catch (error) {
+          if (container) {
+            container.innerHTML = '';
+          }
+        }
+      };
+
+    } catch (err) {
+      console.error('Error creating district map preview:', err);
+      setError('Failed to create map visualization');
+    }
+  }, [portugalTopoJson, districtForecast, isLoading, height]);
+
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center ${className}`} style={{ height }}>
+        <div className="text-gray-500 text-sm">A carregar mapa...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={`flex items-center justify-center ${className}`} style={{ height }}>
+        <div className="text-red-500 text-sm">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`relative w-full ${className}`} style={{ minHeight: height }}>
+      <div 
+        ref={containerRef} 
+        className="w-full h-full"
+      />
+      
+      {/* Tooltip */}
+      {tooltip.show && (
+        <div
+          className="absolute z-10 bg-white border border-gray-200 rounded-lg shadow-lg p-3 pointer-events-none"
+          style={{
+            left: tooltip.x + 10,
+            top: tooltip.y - 10,
+            transform: tooltip.x > 200 ? 'translateX(-100%)' : 'none'
+          }}
+          dangerouslySetInnerHTML={{ __html: tooltip.content }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDistrictData.ts
+++ b/src/hooks/useDistrictData.ts
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { DistrictForecast, GeometryDataMap } from '@/types/geography';
+
+// Function to identify island geometries belonging to aggregated regions
+export const getRegionForIsland = (islandName: string): string => {
+  const azoresIslands = [
+    "Ilha do Faial", "Ilha de São Jorge", "Ilha da Graciosa", "Ilha Terceira", 
+    "Ilha das Flores", "Ilha do Corvo", "Ilha de São Miguel", "Ilha de Santa Maria", "Ilha do Pico"
+  ];
+  const madeiraIslands = ["Ilha da Madeira", "Ilha de Porto Santo"];
+
+  if (azoresIslands.includes(islandName)) return "Açores";
+  if (madeiraIslands.includes(islandName)) return "Madeira";
+  return islandName; // If not an island, return the name itself (continental district)
+};
+
+/**
+ * Custom hook to process district forecast data and create lookup maps
+ */
+export function useDistrictData(districtForecast: DistrictForecast[]) {
+  const processedData = useMemo(() => {
+    // Process forecast data to find the winning party per district/region
+    const normalizedForecast = districtForecast.map(d => ({
+      ...d,
+      district_name: d.district_name === "Açores" ? "Açores" : d.district_name
+    }));
+
+    const forecastByDistrict = d3.group(normalizedForecast, d => d.district_name);
+    const winningParty = new Map<string, string>();
+    const districtProbs = new Map<string, Record<string, number>>();
+
+    // Extract winning party and probabilities for each district
+    for (const [districtName, forecastEntries] of forecastByDistrict) {
+      if (forecastEntries && forecastEntries.length > 0) {
+        const districtData = forecastEntries[0];
+        districtProbs.set(districtName, districtData.probs || {});
+        winningParty.set(districtName, districtData.winning_party || 'default');
+      } else {
+        districtProbs.set(districtName, {});
+        winningParty.set(districtName, 'default');
+      }
+    }
+
+    return { winningParty, districtProbs };
+  }, [districtForecast]);
+
+  return processedData;
+}
+
+/**
+ * Custom hook to create geometry data map from district data
+ */
+export function useGeometryDataMap(
+  features: Array<{ properties: { NAME_1: string } }>,
+  winningParty: Map<string, string>,
+  districtProbs: Map<string, Record<string, number>>
+) {
+  const geometryDataMap = useMemo(() => {
+    const map = new Map<string, GeometryDataMap>();
+    
+    for (const feature of features) {
+      const geometryName = feature.properties.NAME_1;
+      const regionOrDistrictName = getRegionForIsland(geometryName);
+      const winnerForRegion = winningParty.get(regionOrDistrictName);
+      const actualProbs = districtProbs.get(regionOrDistrictName) || {};
+
+      map.set(geometryName, {
+        winner: winnerForRegion || 'default',
+        forecast: actualProbs
+      });
+    }
+
+    return map;
+  }, [features, winningParty, districtProbs]);
+
+  return geometryDataMap;
+}

--- a/src/hooks/useDistrictData.ts
+++ b/src/hooks/useDistrictData.ts
@@ -1,19 +1,7 @@
 import { useMemo } from 'react';
 import * as d3 from 'd3';
 import type { DistrictForecast, GeometryDataMap } from '@/types/geography';
-
-// Function to identify island geometries belonging to aggregated regions
-export const getRegionForIsland = (islandName: string): string => {
-  const azoresIslands = [
-    "Ilha do Faial", "Ilha de São Jorge", "Ilha da Graciosa", "Ilha Terceira", 
-    "Ilha das Flores", "Ilha do Corvo", "Ilha de São Miguel", "Ilha de Santa Maria", "Ilha do Pico"
-  ];
-  const madeiraIslands = ["Ilha da Madeira", "Ilha de Porto Santo"];
-
-  if (azoresIslands.includes(islandName)) return "Açores";
-  if (madeiraIslands.includes(islandName)) return "Madeira";
-  return islandName; // If not an island, return the name itself (continental district)
-};
+import { getRegionForIsland } from '@/lib/geography/regionMapping';
 
 /**
  * Custom hook to process district forecast data and create lookup maps

--- a/src/hooks/useTooltip.ts
+++ b/src/hooks/useTooltip.ts
@@ -1,0 +1,45 @@
+import { useState, useCallback } from 'react';
+import type { TooltipState } from '@/types/geography';
+import { partyColors } from '@/lib/config/colors';
+
+/**
+ * Custom hook for managing tooltip state and logic
+ */
+export function useTooltip() {
+  const [tooltip, setTooltip] = useState<TooltipState>({ 
+    show: false, 
+    x: 0, 
+    y: 0, 
+    content: null 
+  });
+
+  const showTooltip = useCallback((
+    x: number,
+    y: number,
+    regionName: string,
+    forecast: Record<string, number>
+  ) => {
+    const parties = Object.entries(forecast)
+      .filter(([party]) => partyColors.hasOwnProperty(party))
+      .sort(([,a], [,b]) => b - a)
+      .slice(0, 3);
+
+    if (parties.length > 0) {
+      setTooltip({
+        show: true,
+        x,
+        y,
+        content: {
+          regionName,
+          parties
+        }
+      });
+    }
+  }, []);
+
+  const hideTooltip = useCallback(() => {
+    setTooltip({ show: false, x: 0, y: 0, content: null });
+  }, []);
+
+  return { tooltip, showTooltip, hideTooltip };
+}

--- a/src/hooks/useTopoJsonData.ts
+++ b/src/hooks/useTopoJsonData.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import type { PortugalTopoJSON } from '@/types/geography';
+
+/**
+ * Custom hook to load and manage TopoJSON data for Portuguese districts
+ */
+export function useTopoJsonData() {
+  const [portugalTopoJson, setPortugalTopoJson] = useState<PortugalTopoJSON | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadTopoJson() {
+      try {
+        const response = await fetch('/data/Portugal-Distritos-Ilhas_TopoJSON.json');
+        if (!response.ok) {
+          throw new Error('Failed to load TopoJSON data');
+        }
+        const data = await response.json();
+        setPortugalTopoJson(data);
+        setIsLoading(false);
+      } catch (err) {
+        console.error('Error loading TopoJSON:', err);
+        setError('Failed to load map data');
+        setIsLoading(false);
+      }
+    }
+
+    loadTopoJson();
+  }, []);
+
+  return { portugalTopoJson, isLoading, error };
+}

--- a/src/lib/geography/regionMapping.ts
+++ b/src/lib/geography/regionMapping.ts
@@ -1,0 +1,30 @@
+/**
+ * Central mapping utility for Portuguese geographic regions
+ */
+
+/**
+ * Maps island names to their corresponding aggregated regions (Açores/Madeira)
+ * or returns the original name for continental districts
+ */
+export function getRegionForIsland(islandName: string): string {
+  const azoresIslands = [
+    "Ilha do Faial", 
+    "Ilha de São Jorge", 
+    "Ilha da Graciosa", 
+    "Ilha Terceira", 
+    "Ilha das Flores", 
+    "Ilha do Corvo", 
+    "Ilha de São Miguel", 
+    "Ilha de Santa Maria", 
+    "Ilha do Pico"
+  ];
+  
+  const madeiraIslands = [
+    "Ilha da Madeira", 
+    "Ilha de Porto Santo"
+  ];
+
+  if (azoresIslands.includes(islandName)) return "Açores";
+  if (madeiraIslands.includes(islandName)) return "Madeira";
+  return islandName; // If not an island, return the name itself (continental district)
+}

--- a/src/types/geography.ts
+++ b/src/types/geography.ts
@@ -1,0 +1,81 @@
+// TypeScript types for Portuguese geographic data structures
+
+export interface DistrictProperties {
+  NAME_1: string;
+  OBJECTID: number;
+  NAME_0?: string;
+  ID_1?: number;
+  TYPE_1?: string;
+  ENGTYPE_1?: string;
+  NL_NAME_1?: string;
+  VARNAME_1?: string;
+}
+
+export interface DistrictGeometry {
+  type: 'Polygon' | 'MultiPolygon';
+  coordinates: number[][][] | number[][][][];
+}
+
+export interface DistrictFeature {
+  type: 'Feature';
+  properties: DistrictProperties;
+  geometry: DistrictGeometry;
+  id?: string | number;
+}
+
+export interface DistrictFeatureCollection {
+  type: 'FeatureCollection';
+  features: DistrictFeature[];
+}
+
+export interface PortugalTopoJSON {
+  type: 'Topology';
+  objects: {
+    ilhasGeo2: {
+      type: 'GeometryCollection';
+      geometries: Array<{
+        type: 'Polygon' | 'MultiPolygon';
+        properties: DistrictProperties;
+        arcs: number[][] | number[][][];
+      }>;
+    };
+  };
+  arcs: number[][][];
+  transform?: {
+    scale: [number, number];
+    translate: [number, number];
+  };
+  bbox?: [number, number, number, number];
+}
+
+export interface DistrictForecast {
+  district_name: string;
+  winning_party: string;
+  probs: Record<string, number>;
+}
+
+export interface GeometryDataMap {
+  winner: string;
+  forecast: Record<string, number>;
+}
+
+export interface TooltipData {
+  regionName: string;
+  parties: [string, number][];
+}
+
+export interface TooltipState {
+  show: boolean;
+  x: number;
+  y: number;
+  content: TooltipData | null;
+}
+
+// Helper type for district selection in map components
+export interface SelectedDistrict {
+  id: string;
+  probs: Record<string, number>;
+}
+
+// Type for the region mapping function
+export type RegionMapper = (islandName: string) => string;


### PR DESCRIPTION
## Summary
Implements a complete interactive district map feature with geographic analysis capabilities for estimador.pt, addressing GitHub issue #6.

### ✨ New Features
- **Full Interactive Map Page** (`/map`): Dedicated page with clickable districts, detailed vote breakdowns, and responsive design
- **Homepage Map Preview**: Integrated district map preview in optimized layout with working hover functionality
- **Geographic Analysis**: Visual representation of election forecasts across Portuguese districts with proper TopoJSON rendering
- **Mobile Optimization**: Responsive design with container-based sizing (320px mobile, 384px desktop)

### 🎨 UI/UX Improvements
- **Smart Layout**: 2/3 polling chart + 1/3 map grid arrangement for better visual balance
- **Interactive Tooltips**: Hover functionality showing district names and top 3 party vote percentages
- **Navigation Integration**: Added map link to header navigation with internationalization support
- **Professional Design**: Clean, newspaper-style layout matching FiveThirtyEight standards

### 🔧 Technical Implementations
- **TopoJSON Processing**: Comprehensive handling of Portuguese geographic data including islands (Açores, Madeira)
- **Event Handling**: Robust DOM event management using Observable Plot's built-in patterns
- **Data Mapping**: Efficient district-to-forecast data mapping with proper party filtering
- **Error Handling**: Comprehensive cleanup and error management for map components
- **Configuration**: Fixed Next.js development server issues with static export settings

### 📱 Responsive Design
- **Container-based Sizing**: Dynamic width and height calculation for optimal display
- **Mobile-First**: Responsive breakpoints with Tailwind CSS classes (`h-80 md:h-96`)
- **Touch-Friendly**: Proper cursor states and hover interactions

### 🌐 Internationalization
- **Bilingual Support**: Added Portuguese and English translations for map-related content
- **Consistent Terminology**: Proper European Portuguese electoral terminology throughout

## Test Plan
- [x] Map renders correctly on both `/map` page and homepage preview
- [x] Hover tooltips work properly showing district data
- [x] Click functionality works for district selection on full map page
- [x] Responsive design functions across mobile, tablet, and desktop
- [x] Navigation integration works with proper internationalization
- [x] Data loads correctly from TopoJSON and district forecast sources
- [x] Error states handle missing data gracefully

## Screenshots
The interactive map displays Portuguese districts color-coded by leading party with hover tooltips showing vote share breakdowns. Homepage integration provides an engaging preview that encourages exploration of the full map feature.

🤖 Generated with [Claude Code](https://claude.ai/code)